### PR TITLE
Updated Anaconda version in Dockerfile, current pytorch had issues with included python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
 libglib2.0-0 libxext6 libsm6 libxrender1 \
 git mercurial subversion
 
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
-/bin/bash ~/anaconda.sh -b -p /opt/conda && \
-rm ~/anaconda.sh && \
-ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-conda install pytorch torchvision cuda100 -c pytorch && \
-echo "conda activate base" >> ~/.bashrc
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2019.07-Linux-x86_64.sh -O ~/anaconda.sh 
+RUN /bin/bash ~/anaconda.sh -b -p /opt/conda 
+RUN rm ~/anaconda.sh 
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh 
+RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc 
+RUN conda install pytorch torchvision cuda100 -c pytorch 
+RUN echo "conda activate base" >> ~/.bashrc
 
 #all the code samples for the video series
 VOLUME ["/src"]


### PR DESCRIPTION
Current PyTorch version had issues working with Python 3.7.0 included in Anaconda distribution present in the old Docker file. 
It lead to downgrade of Python to 3.6.9 during Conda install execution, what somehow broke the whole Conda environment.
In addition I've split one of the Dockerfile RUN commands into separate steps, what makes experimenting with the Docker configuration much faster when changing a single command there.

Note: I did't yet run all the code in the course, so I cannot vouch that all of it works. But at least the container starts the Jupiter notebook, what was not the case with the original Dockerfile content.