### PR TITLE
Resolved issue when conda install pytorch downgraded python to version 3.6.9 making environment unusable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,13 +8,13 @@ RUN apt-get update --fix-missing && apt-get install -y wget bzip2 ca-certificate
 libglib2.0-0 libxext6 libsm6 libxrender1 \
 git mercurial subversion
 
-RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-5.3.0-Linux-x86_64.sh -O ~/anaconda.sh && \
-/bin/bash ~/anaconda.sh -b -p /opt/conda && \
-rm ~/anaconda.sh && \
-ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh && \
-echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc && \
-conda install pytorch torchvision cuda100 -c pytorch && \
-echo "conda activate base" >> ~/.bashrc
+RUN wget --quiet https://repo.anaconda.com/archive/Anaconda3-2019.07-Linux-x86_64.sh -O ~/anaconda.sh 
+RUN /bin/bash ~/anaconda.sh -b -p /opt/conda 
+RUN rm ~/anaconda.sh 
+RUN ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh 
+RUN echo ". /opt/conda/etc/profile.d/conda.sh" >> ~/.bashrc 
+RUN conda install pytorch torchvision cuda100 -c pytorch 
+RUN echo "conda activate base" >> ~/.bashrc
 
 #all the code samples for the video series
 VOLUME ["/src"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ WORKDIR /src
 EXPOSE 8888
 
 #this has security disabled which is less fuss for learning purposes
-CMD jupyter notebook --port=8888 --ip=0.0.0.0 --allow-root --NotebookApp.token='' --NotebookApp.disable_check_xsrf=True
+CMD jupyter notebook --port=8888 --ip=0.0.0.0 --allow-root --NotebookApp.token='ignore' --NotebookApp.disable_check_xsrf=True --no-browser

--- a/readme.md
+++ b/readme.md
@@ -66,8 +66,11 @@ This is configured to run with `docker-compose`, so just start things up with
 
 `docker-compose up`
 
-And then you can just go to http://localhost:8888 to get started. All the notbook security is 
-switched off as this is packed up for learning purposes, one less thing to worry about.
+And then you can just go to http://localhost:8888?token=ignore to get started. 
+Initially all the notbook security was switched off as this is packed up 
+for learning purposes, but because some Visual Code Studio / Jupyter 
+Notebook combinations don't allow for an empty token, 
+placeholder value: ?token=ignore was added to the url.
 
 
 ### Technical Requirements


### PR DESCRIPTION
It appears that current Pytorch version is incompatible with Python 3.7.0 included in Anaconda distribution installed in "old" Dockerfile. 
It lead to downgrade of Python to version 3.6.9 what made the whole Conda environment within container unusable.
Currently the Anaconda distribution was updated to the most current version (as of today).
In addition:
* One RUN command was split into a few smaller ones (to make it easier to debug and "play" with the image and container).
* ?token=ignore was added to the jupyter notebook URL, because without a token value some (i.e. mine ;-)) version of Visual Studio Code wasn't able to connect to the server.
